### PR TITLE
Support flags for dockerfile commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Possible exceptions:
 
 ```python
 >>> pprint.pprint(dockerfile.parse_file('testfiles/Dockerfile.ok'))
-(Command(cmd='from', sub_cmd=None, json=False, original='FROM ubuntu:xenial', start_line=1, value=('ubuntu:xenial',)),
- Command(cmd='cmd', sub_cmd=None, json=True, original='CMD ["echo", "hi"]', start_line=2, value=('echo', 'hi')))
+(Command(cmd='from', sub_cmd=None, json=False, original='FROM ubuntu:xenial', start_line=1, flags=(), value=('ubuntu:xenial',)),
+ Command(cmd='cmd', sub_cmd=None, json=True, original='CMD ["echo", "hi"]', start_line=2, flags=(), value=('echo', 'hi')))
 ```
 
 #### `dockerfile.parse_string(s)`
@@ -59,7 +59,7 @@ Possible exceptions:
 
 ```python
 >>> dockerfile.parse_string('FROM ubuntu:xenial')
-(Command(cmd='from', sub_cmd=None, json=False, original='FROM ubuntu:xenial', start_line=1, value=('ubuntu:xenial',)),)
+(Command(cmd='from', sub_cmd=None, json=False, original='FROM ubuntu:xenial', start_line=1, flags=(), value=('ubuntu:xenial',)),)
 ```
 
 ## go library

--- a/parse.go
+++ b/parse.go
@@ -17,6 +17,7 @@ type Command struct {
 	Json      bool     // whether the value is written in json form
 	Original  string   // The original source line
 	StartLine int      // The original source line number
+	Flags     []string // Any flags such as `--from=...` for `COPY`.
 	Value     []string // The contents of the command (ex: `ubuntu:xenial`)
 }
 
@@ -63,6 +64,7 @@ func ParseReader(file io.Reader) ([]Command, error) {
 			Cmd:       child.Value,
 			Original:  child.Original,
 			StartLine: child.StartLine,
+			Flags:     child.Flags,
 		}
 
 		// Only happens for ONBUILD

--- a/parse_test.go
+++ b/parse_test.go
@@ -22,6 +22,7 @@ func TestParseReader(t *testing.T) {
 	dockerfile := `FROM ubuntu:xenial
 RUN echo hi > /etc/hi.conf
 CMD ["echo"]
+HEALTHCHECK --retries=5 CMD echo hi
 ONBUILD ADD foo bar
 ONBUILD RUN ["cat", "bar"]
 `
@@ -32,12 +33,14 @@ ONBUILD RUN ["cat", "bar"]
 			Cmd:       "from",
 			Original:  "FROM ubuntu:xenial",
 			StartLine: 1,
+			Flags:     []string{},
 			Value:     []string{"ubuntu:xenial"},
 		},
 		Command{
 			Cmd:       "run",
 			Original:  "RUN echo hi > /etc/hi.conf",
 			StartLine: 2,
+			Flags:     []string{},
 			Value:     []string{"echo hi > /etc/hi.conf"},
 		},
 		Command{
@@ -45,13 +48,23 @@ ONBUILD RUN ["cat", "bar"]
 			Json:      true,
 			Original:  "CMD [\"echo\"]",
 			StartLine: 3,
+			Flags:     []string{},
 			Value:     []string{"echo"},
+		},
+		Command{
+			Cmd:       "healthcheck",
+			SubCmd:    "",
+			Original:  "HEALTHCHECK --retries=5 CMD echo hi",
+			StartLine: 4,
+			Flags:     []string{"--retries=5"},
+			Value:     []string{"CMD", "echo hi"},
 		},
 		Command{
 			Cmd:       "onbuild",
 			SubCmd:    "add",
 			Original:  "ONBUILD ADD foo bar",
-			StartLine: 4,
+			StartLine: 5,
+			Flags:     []string{},
 			Value:     []string{"foo", "bar"},
 		},
 		Command{
@@ -59,7 +72,8 @@ ONBUILD RUN ["cat", "bar"]
 			SubCmd:    "run",
 			Json:      true,
 			Original:  "ONBUILD RUN [\"cat\", \"bar\"]",
-			StartLine: 5,
+			StartLine: 6,
+			Flags:     []string{},
 			Value:     []string{"cat", "bar"},
 		},
 	}
@@ -80,6 +94,7 @@ func TestParseFile(t *testing.T) {
 			Cmd:       "from",
 			Original:  "FROM ubuntu:xenial",
 			StartLine: 1,
+			Flags:     []string{},
 			Value:     []string{"ubuntu:xenial"},
 		},
 		Command{
@@ -87,6 +102,7 @@ func TestParseFile(t *testing.T) {
 			Original:  "CMD [\"echo\", \"hi\"]",
 			StartLine: 2,
 			Json:      true,
+			Flags:     []string{},
 			Value:     []string{"echo", "hi"},
 		},
 	}

--- a/pylib/support.c
+++ b/pylib/support.c
@@ -26,11 +26,12 @@ PyObject* PyDockerfile_NewCommand(
     PyObject* json,
     PyObject* original,
     PyObject* start_line,
+    PyObject* flags,
     PyObject* value
 ) {
     return PyObject_CallFunction(
-        PyDockerfile_Command, "OOOOOO",
-        cmd, sub_cmd, json, original, start_line, value
+        PyDockerfile_Command, "OOOOOOO",
+        cmd, sub_cmd, json, original, start_line, flags, value
     );
 }
 
@@ -51,7 +52,7 @@ static PyObject* _setup_module(PyObject* module) {
         PyObject* collections = PyImport_ImportModule("collections");
         PyDockerfile_Command = PyObject_CallMethod(
             collections, "namedtuple", "ss",
-            "Command", "cmd sub_cmd json original start_line value"
+            "Command", "cmd sub_cmd json original start_line flags value"
         );
         PyObject_SetAttrString(
             PyDockerfile_Command, "__module__",

--- a/tests/dockerfile_test.py
+++ b/tests/dockerfile_test.py
@@ -35,30 +35,39 @@ def test_parse_string_success():
         'FROM ubuntu:xenial\n'
         'RUN echo hi > /etc/hi.conf\n'
         'CMD ["echo"]\n'
+        'HEALTHCHECK --retries=5 CMD echo hi\n'
         'ONBUILD ADD foo bar\n'
         'ONBUILD RUN ["cat", "bar"]\n'
     )
     assert ret == (
         dockerfile.Command(
-            cmd='from', sub_cmd=None, json=False, value=('ubuntu:xenial',),
+            cmd='from', sub_cmd=None, json=False, flags=(),
+            value=('ubuntu:xenial',),
             start_line=1, original='FROM ubuntu:xenial',
         ),
         dockerfile.Command(
-            cmd='run', sub_cmd=None, json=False,
+            cmd='run', sub_cmd=None, json=False, flags=(),
             value=('echo hi > /etc/hi.conf',),
             start_line=2, original='RUN echo hi > /etc/hi.conf',
         ),
         dockerfile.Command(
-            cmd='cmd', sub_cmd=None, json=True, value=('echo',),
+            cmd='cmd', sub_cmd=None, json=True, flags=(), value=('echo',),
             start_line=3, original='CMD ["echo"]',
         ),
         dockerfile.Command(
-            cmd='onbuild', sub_cmd='add', json=False, value=('foo', 'bar'),
-            start_line=4, original='ONBUILD ADD foo bar',
+            cmd='healthcheck', sub_cmd=None, json=False,
+            flags=('--retries=5',), value=('CMD', 'echo hi'),
+            start_line=4, original='HEALTHCHECK --retries=5 CMD echo hi',
         ),
         dockerfile.Command(
-            cmd='onbuild', sub_cmd='run', json=True, value=('cat', 'bar'),
-            start_line=5, original='ONBUILD RUN ["cat", "bar"]',
+            cmd='onbuild', sub_cmd='add', json=False, flags=(),
+            value=('foo', 'bar'),
+            start_line=5, original='ONBUILD ADD foo bar',
+        ),
+        dockerfile.Command(
+            cmd='onbuild', sub_cmd='run', json=True, flags=(),
+            value=('cat', 'bar'),
+            start_line=6, original='ONBUILD RUN ["cat", "bar"]',
         ),
     )
 
@@ -71,11 +80,11 @@ def test_parse_string_text():
     assert ret == (
         dockerfile.Command(
             cmd='from', sub_cmd=None, json=False, value=('ubuntu:xenial',),
-            start_line=1, original='FROM ubuntu:xenial',
+            start_line=1, original='FROM ubuntu:xenial', flags=(),
         ),
         dockerfile.Command(
             cmd='cmd', sub_cmd=None, json=True, value=('echo', '☃'),
-            start_line=2, original='CMD ["echo", "☃"]',
+            start_line=2, original='CMD ["echo", "☃"]', flags=(),
         ),
     )
 
@@ -84,11 +93,12 @@ def test_parse_file_success():
     ret = dockerfile.parse_file('testfiles/Dockerfile.ok')
     assert ret == (
         dockerfile.Command(
-            cmd='from', sub_cmd=None, json=False, value=('ubuntu:xenial',),
+            cmd='from', sub_cmd=None, json=False, flags=(),
+            value=('ubuntu:xenial',),
             start_line=1, original='FROM ubuntu:xenial',
         ),
         dockerfile.Command(
-            cmd='cmd', sub_cmd=None, json=True, value=('echo', 'hi'),
+            cmd='cmd', sub_cmd=None, json=True, flags=(), value=('echo', 'hi'),
             start_line=2, original='CMD ["echo", "hi"]',
         ),
     )


### PR DESCRIPTION
Resolves #7

CC @spearsem

This is *technically* an api break for `dockerfile.Command` though construction of this type isn't documented.  The _fix_ is easy, just supply `flags=()` to any existing calls.  I'll probably release this as 2.0.0.  I opted for a breaking change over complicating `Command.__new__` which would have needed some iffy C code 😆 .