### PR TITLE
Try go 1.10 for pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ matrix:
             python: 3.5
         -   env: TOXENV=py36 GO=1.7
             python: 3.6
-        -   env: TOXENV=pypy GO=1.7
-            python: pypy-5.3.1
+        -   env: TOXENV=pypy GO=1.10
+            python: pypy
 install:
     - |
         export GOPATH=~/gopath
@@ -19,8 +19,6 @@ install:
         rsync -az . "$TRAVIS_BUILD_DIR"
         cd "$TRAVIS_BUILD_DIR"
         eval "$(gimme $GO)"
-    # workaround for #5
-    - pip install 'cryptography<2'
     - pip install coveralls tox
 script:
     - go get -t


### PR DESCRIPTION
I enabled typedefs to work for go: https://github.com/golang/go/commit/57fa1c7c949c5ea1efd756e2ed0c4442998690a9

Resolves #5