### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 import os
+import sys
 
 from setuptools import Extension
 from setuptools import setup
 
 if not os.path.exists('vendor/github.com/moby/buildkit/frontend'):
-    print('moby checkout is missing!')
-    print('Run `git submodule update --init`')
-    exit(1)
+    sys.exit('moby checkout is missing!\n'
+             'Run `git submodule update --init`')
 
 setup(
     ext_modules=[Extension('dockerfile', ['pylib/main.go'])],


### PR DESCRIPTION
-Use sys.exit over exit as recommended by the docs: https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module
-Send error messages to stderr