### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,16 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus, --unclassifiable-application-module, dockerfile]
+        args: [
+            --py37-plus,
+            --unclassifiable-application-module, dockerfile,
+            --add-import, 'from __future__ import annotations',
+        ]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
         version: '1.17.1'
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [py36]
+    toxenvs: [py37]
     os: linux
     name_postfix: _go_1_16
     pre_test:
@@ -38,7 +38,7 @@ jobs:
         version: '1.16.8'
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38, py39, py310]
     os: linux
     name_postfix: _go_1_17
     pre_test:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -22,7 +21,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
 
 [options]
-python_requires = >=3.6.1
+python_requires = >=3.7
 setup_requires =
     setuptools-golang>=1.7.0
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import platform
 import sys
 

--- a/tests/dockerfile_test.py
+++ b/tests/dockerfile_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import dockerfile

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos