### PR TITLE
Feature/heredocs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/asottile/dockerfile
 go 1.16
 
 require (
-	github.com/moby/buildkit v0.9.0
-	github.com/stretchr/testify v1.7.0
+	github.com/moby/buildkit v0.12.5
+	github.com/stretchr/testify v1.8.3
 )


### PR DESCRIPTION
Added support for properly parsing heredocs in dockerfiles. Addresses #174 .
 - Updated buildkit version to minimum version to support heredocs
 - Added functionality to go parser to properly parse Value and Original fields for heredocs.
 - Added go and docker tests for heredocs